### PR TITLE
Split jobs into multiple files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1.2.2
+        with:
+          node-version: '20'
+      - run: bun install -g typescript@5
+      - run: bun install
+      - run: tsc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,23 +1,9 @@
-name: Fly Deploy
+name: Deploy
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 jobs:
-  build:
-    name: Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v1.2.2
-        with:
-          node-version: '20'
-      - run: bun install -g typescript@5
-      - run: bun install
-      - run: tsc
   deploy:
     name: Deploy
     needs: build


### PR DESCRIPTION
Splits jobs into multiple files so that deployments only run on `main` and builds only happen on pull requests.